### PR TITLE
Option to specify ssl ciphers

### DIFF
--- a/bmcldap.yml.sample
+++ b/bmcldap.yml.sample
@@ -3,6 +3,16 @@ ClientCaCert: "/etc/openldap/cacerts/cacert.pem"
 RemoteServerName: "ldaps.example.com"
 RemoteServerPortTLS: 636
 MinTLSVersion: "1.2"
+CipherSuites:
+  - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+  - "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+  - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+  - "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+  - "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+  - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+  - "TLS_RSA_WITH_AES_256_GCM_SHA384"
+  - "TLS_RSA_WITH_AES_128_CBC_SHA"
+  - "TLS_RSA_WITH_AES_256_CBC_SHA"
 Debug: true
 PortTLS: 443
 PortInsecure: 386

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,6 +46,7 @@ func serve() {
 		RemoteServerPortTLS:     viper.GetInt("RemoteServerPortTLS"),
 		Debug:                   viper.GetBool("Debug"),
 		MinTLSVersion:           viper.GetString("MinTLSVersion"),
+		CipherSuites:            viper.GetStringSlice("CipherSuites"),
 		PortTLS:                 viper.GetInt("PortTLS"),
 		PortInsecure:            viper.GetInt("PortInsecure"),
 		Cert:                    viper.GetString("Cert"),

--- a/pkg/backend_test.go
+++ b/pkg/backend_test.go
@@ -21,6 +21,7 @@ func setup() (*Config, *logrus.Logger) {
 		RemoteServerPortTLS: 636,
 		Debug:               true,
 		MinTLSVersion:       "1.2",
+		CipherSuites:        []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
 		PortTLS:             443,
 		PortInsecure:        386,
 		Cert:                "/etc/bmcldap/server.pem",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	BaseDN              string
 	Config              string
 	MinTLSVersion       string
+	CipherSuites        []string
 	RemoteServerName    string
 	RemoteServerPortTLS int
 	CaCert              string

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -86,23 +86,19 @@ func (bmcLdap *BmcLdap) LoadTlsConfig(c *config.Config) *tls.Config {
 		}).Warning("Using TLS 1.1, ignoring unsupported version " + c.MinTLSVersion)
 	}
 
-	// Please Note: TLSv1.3 Ciphers cannot be configured as of today
+	// Please Note: TLSv1.3 Ciphers cannot be defined as of today
 	var cipherSuitesTLS []uint16
 
 	if len(c.CipherSuites) > 0 {
-
-		// Check if the Cipher Keys Belong to Secure Ciphers
-		for _, secureCipher := range tls.CipherSuites() {
+		// Including Both Secure and Insecure Ciphers, in-case anyone wants to use Insecure ones for compatibility reasons
+		allCipherSuites := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+		// Check if the Cipher Keys Belong to Ciphers supported by Go TLS module
+		for _, secureCipher := range allCipherSuites {
 			if sliceContains(c.CipherSuites, secureCipher.Name) {
 				cipherSuitesTLS = append(cipherSuitesTLS, secureCipher.ID)
 			}
 		}
-		// In case anyone wants to use Insecure Ciphers for compatibility issues
-		for _, inSecureCipher := range tls.InsecureCipherSuites() {
-			if sliceContains(c.CipherSuites, inSecureCipher.Name) {
-				cipherSuitesTLS = append(cipherSuitesTLS, inSecureCipher.ID)
-			}
-		}
+
 	}
 	return &tls.Config{
 		Certificates:       []tls.Certificate{cert},


### PR DESCRIPTION
This would enable an option in the configuration file to pass a list of TLS Ciphers to be used in place of the default TLS ciphers